### PR TITLE
Tweak version constraint for Java

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ issues_url       'https://github.com/JamesMGreene/chef-gocd-agent/issues' if res
 
 
 # GoCD depends on the OpenJDK 7 (1.7.x) JRE
-depends 'java', '~> 1.31.0'
+depends 'java', '~> 1.31'
 
 
 


### PR DESCRIPTION
I wasn't able to use the latest Java cookbook (1.35.0) because the pessimistic version constraint had the patch number included. This prevents using any versions where the minor number increases.   https://docs.chef.io/cookbook_versions.html
